### PR TITLE
1. Metadata and references properties were added to spineOutputsTask …

### DIFF
--- a/examples/annotationWorkflow/materialized-task.json
+++ b/examples/annotationWorkflow/materialized-task.json
@@ -10,5 +10,5 @@
     }
   },
   "status": "TODO",
-  "assignedTo": "admin@test.com"
+  "assignedUser": "admin@test.com"
 }

--- a/examples/annotationWorkflow/task-annotation.json
+++ b/examples/annotationWorkflow/task-annotation.json
@@ -18,22 +18,25 @@
   },
   "inputs": {
     "images" : {
+      "name": "Images",
       "description": "List of image to be annotated",
       "type": "imageEntityInOut",
       "filter":{},
-      "format":"nifti",
+      "imageEntityInOut_FileFormat":"nii",
       "isList": true,
-      "imageType":"Anatomical",
-      "name": "Images"
+      "imageEntityInOut_Type":"ANATOMICAL"
     }
   },
   "outputs": {
     "roi" : {
+      "name": "Created ROIs",
       "description": "List of annotations",
-      "metadata":{},
-      "reference":{},
+      "type": "roiInOut",
       "isList": true,
-      "name": "ROIs"
+      "roiInOut_FileFormat": "json",
+      "schema": "https://raw.githubusercontent.com/SPINEProject/SPINE-json-schema/master/schemas/roi.schema.json",
+      "metadata":{},
+      "reference":{}
     }
   }
 }

--- a/schemas/core.schema.json
+++ b/schemas/core.schema.json
@@ -2,7 +2,7 @@
   "$id":"https://raw.githubusercontent.com/SPINEProject/SPINE-json-schema/master/schemas/core.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SPINE Core",
-  "TODO": [
+  "TODOS": [
     "TODO #1. Filter schema is to be defined.",
     "TODO #2. Metadata schema is to be defined.",
     "TODO #3. Reference schema is to be defined.",

--- a/schemas/materializedTask.schema.json
+++ b/schemas/materializedTask.schema.json
@@ -1,5 +1,5 @@
 {
-  "id":"https://raw.githubusercontent.com/SPINEProject/SPINE-json-schema/master/schemas/materializedTask.json",
+  "$id":"https://raw.githubusercontent.com/SPINEProject/SPINE-json-schema/master/schemas/materializedTask.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
@@ -9,8 +9,9 @@
       "type":"string"
     },
     "status":{
-      "type":"boolean",
-      "description":"Is the task done?"
+      "type":"string",
+      "description":"Status of the materializedTask.",
+      "enum": ["TODO", "SAVE", "SUBMITTED"]
     },
     "assignedUser": {
       "type":"string",
@@ -25,7 +26,7 @@
           "additionalProperties": false,
           "properties": {
             "value":{
-              "description":"Value of the input",
+              "description":"Value of the input"
             }
           }
         }
@@ -37,11 +38,11 @@
       "properties": {
         "toolId":{
           "type":"string",
-          "description":"Reference to the tool to use",
+          "description":"Reference to the tool to use"
         },
         "taskExecutorId":{
           "type":"string",
-          "description":"Reference to the task executor",
+          "description":"Reference to the task executor"
         }
       }
     }

--- a/schemas/task.schema.json
+++ b/schemas/task.schema.json
@@ -5,7 +5,8 @@
   "title": "Task",
   "TODOS": [
     "TODO #1. spineInputsTask - Insert restrictions for the use of filter and idInDescriptor.",
-    "TODO #2. spineInputsTask - Insert restrictions for the use of idInDescriptor."
+    "TODO #2. spineInputsTask - Insert restrictions for the use of idInDescriptor.",
+    "TODO #3. spineOutputsTask - Define the output metadata for the spine types that we have. This allows us to know what to expect in each case."
   ],
   "definitions":{
 
@@ -20,7 +21,7 @@
               "$ref":"core.schema.json#/definitions/filter"
             },
             "idInDescriptor": {
-              "description":"Id of the Input/Output in the descriptor. This is required for automatica tasks, for now wraped using boutiques.",
+              "description":"Id of the Input/Output in the descriptor. This is required for automatic tasks, for now wraped using boutiques.",
               "type":"string"
             }
           },
@@ -41,6 +42,14 @@
             "idInDescriptor": {
               "description":"Id of the Input/Output in the descriptor. This is required for automatica tasks, for now wraped using boutiques.",
               "type":"string"
+            },
+            "metadata": {
+              "description":"Metadata to add to the output",
+              "type":"object"
+            },
+            "reference": {
+              "description":"Reference to add to the output",
+              "type":"object"
             }
           },
           "allOf":[


### PR DESCRIPTION
…in task.schema.json

2. Status of MaterializedTask was changed from boolean to string with possible vaules: TODO, SAVED, SUBMITTED.
3. Task annotation example was modified to be compliant with the schemas.
4. Type the example of MaterializedTask was corrected.